### PR TITLE
fix: #23 fatal error in dev icons selection

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -25,7 +25,7 @@ const defaultSettings = {
 	download: "PNG",
 	author: 'Rutik Wankhade',
 	icon: { 'label': 'react', 'value': 'react' },
-	devIconOptions: {},
+	devIconOptions: [],
 	font: 'font-Anek',
 	theme: 'background',
 	customIcon: '',


### PR DESCRIPTION
### Scope

- The default `devIconOptions` state should be of array type instead of an Object.