### PR TITLE
fix:The first theme image is highly out of range

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,11 @@
     height:36rem;
 }
 
+/* Solve the problem of poor display effect caused by the height of the cover image exceeding the range under the first theme */
+.h-max.w-full {
+    height: 420px;
+}
+
 .h-99{
     height:35rem;
 }


### PR DESCRIPTION
Solve the problem of poor display effect caused by the height of the cover image exceeding the range under the first theme

Before modification
![image](https://github.com/rutikwankhade/CoverView/assets/93815242/080e1a3a-907f-45db-86ed-09d7b6a4b398)

After modification
![image](https://github.com/rutikwankhade/CoverView/assets/93815242/155c1079-316f-4615-af18-70754056c54c)

After the modification, the author information originally caused by the height cannot be displayed normally, and it can be displayed successfully now.
![image](https://github.com/rutikwankhade/CoverView/assets/93815242/b835c2b4-8679-4745-9db4-8e33b336872b)
